### PR TITLE
fix(events): don't cover location links on clickable event entries

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -40,7 +40,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     eventElement.classList.remove('bg-light');
                 });
                 if (event.url) {
-                    eventElement.addEventListener('click', () => {
+                    eventElement.addEventListener('click', (clickEvent) => {
+                        if (clickEvent.target.tagName === 'SPAN' && clickEvent.target.parentElement.tagName === 'A') {
+                            return;
+                        }
                         window.open(event.url, '_blank');
                     });
                     eventElement.classList.add('cursor-pointer');


### PR DESCRIPTION
Not the most elegant solution but also not the most complex one.
Location links are `<span>`s wrapped inside a `<a href=...>`, so when the entry is clicked we check whether the click was on the link or not to suppress opening the other URL.