### PR TITLE
enhancement(events-parser): multi-line extra, more robust parsing

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -75,7 +75,6 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch('/events.json')
         .then(response => response.json())
         .then(all_events => {
-            all_events.sort((a, b) => new Date(a.start) - new Date(b.start));
             const now = new Date();
             events = all_events.filter((event) => new Date(event.end) >= now);
             fillEvents(0);


### PR DESCRIPTION
The previous ICS event description parsing split every line into a key-value pair, making things possible break. Especially that allowed only a single "extra" line.
The new approach only extracts the relevant information that is used in the JSON file and treats the rest as extra. Additionally it allows empty lines between the "metadata" in the description and the extra text without adding those blank lines into the extra text.
This change also does the sorting of events on build-time instead of client-side on every page load, thus increasing the load times by a tiny amount.