### PR TITLE
fix(redirects): `target` not replaced in meta, better js

### DIFF
--- a/src/pug/layouts/redirect.pug
+++ b/src/pug/layouts/redirect.pug
@@ -16,8 +16,8 @@ html(lang='de')
 
         link(rel='canonical', href=target)
         script
-            | location = "#{target}"
-        meta(http-equiv='refresh' content='0; url=#{target}')
+            | window.location.replace("#{target}");
+        meta(http-equiv='refresh', content=`0; url=${target}`)
         meta(name='robots', content='noindex')
 
     body


### PR DESCRIPTION
The problem:

![redirect](https://github.com/user-attachments/assets/36c7bf93-d750-4540-9b0a-657281175def)


The syntax #{variable} seems to only work when being surrounded by word boundaries (space, newline, line start or end). For usage inside another string, the syntax with backticks and dollar-sign seems the way to go.

The explicit syntax of window.location.href is preferred over setting location directly, this seems a relict from the past for compatibility reasons. See the following link: <https://stackoverflow.com/a/1865840/3144667>